### PR TITLE
Feature/takeoff landing yaw reference

### DIFF
--- a/reference/GO_TO_FLIGHT_INITIAL_STATE_REFERENCE.m
+++ b/reference/GO_TO_FLIGHT_INITIAL_STATE_REFERENCE.m
@@ -1,0 +1,116 @@
+classdef GO_TO_FLIGHT_INITIAL_STATE_REFERENCE < handle
+    % TAKEOFF_REFERENCEの後にカスケードで実行されることを想定しているクラス
+    % 9次多項式を用いて、緩やかにflightフェーズの初期状態[x;y;z;yaw]へと移行
+  properties
+    self
+    base_state  % takeoff高度に収束し、移行し始めたときの[x; y; z; yaw]
+    base_time   % takeoff高度に収束し、移行し始めたときの時刻
+    goal_state % [x; y; z; yaw]
+    takeoff_ref_class
+    te          % takeoff高度に収束してから移行するまでの設定時間
+    result
+    sigma = 0.05 % 高度収束判定の閾値[m]
+    fInit = 0
+    fCount = 0
+    fConvergence = false
+  end
+
+  methods
+    function obj = GO_TO_FLIGHT_INITIAL_STATE_REFERENCE(self, opts)
+        arguments
+            self 
+            opts.flight_ref_class = [] % flight refクラスを陽に指定しても良い。指定がない場合はdoメソッド内で値を取得
+            opts.te = 5 % takeoff高度に収束してから何秒で移行完了させるか
+        end
+      obj.self = self;
+      if isprop(obj.self.reference, "takeoff") % 名前をtakeoffに限定
+          if ~isa(obj.self.reference.takeoff, "TAKEOFF_REFERENCE")
+              error("agent.reference.takeoffにはTAKEOFF_REFERENCEを使用してください")
+          end
+      else
+          error("agent.reference.takeoffを本クラスの前に定義してください");
+      end
+      obj.takeoff_ref_class = obj.self.reference.takeoff;
+
+      if ~isempty(opts.flight_ref_class)
+          xd = opts.flight_ref_class.func(0);
+          obj.goal_state = xd(1:4);
+      end
+
+      if isfield(opts, "te"),obj.te = opts.te;
+      else, obj.te = obj.takeoff_ref_class.te; % te指定がない時はtakeoffクラスのteを引継ぎ
+      end
+
+      obj.result.state = STATE_CLASS(struct('state_list',["xd","p","v"],'num_list',[20,3,3]));
+    end
+
+    function  result= do(obj,varargin)
+        % [varargin] time,cha,logger,env
+        if (obj.fInit < 2 || isempty(obj.goal_state)) % 初期化みたいなもの。本当はインスタンス生成時にやりたい
+            xd = obj.self.reference.(obj.self.cha_allocation.f.reference).func(0);
+            obj.goal_state = xd(1:4);
+            if varargin{2} == 't'
+                obj.fInit = obj.fInit + 1;
+            end
+        end
+
+        if abs( obj.self.estimator.(obj.self.cha_allocation.t.estimator).result.state.p(3)-obj.takeoff_ref_class.zd ) < obj.sigma
+            % 高度が収束判定の閾値obj.sigma以下ならカウントアップ
+            obj.fCount = obj.fCount + 1;
+            if obj.fCount >= 10, obj.fConvergence=true; end
+        else
+            obj.fCount = 0;
+        end
+
+        t = varargin{1}.t;
+        if (t - obj.takeoff_ref_class.base_time > obj.takeoff_ref_class.te*1.5 && ... takeoff.te*1.5は余裕を持たせるためのテキトーな値
+            obj.fConvergence)
+            if obj.fInit == 2
+                obj.base_time = t;
+                obj.base_state = [obj.self.estimator.result.state.p(1:2);...% x,y : current position
+                                  obj.self.reference.result.state.p(3);...  % z : reference using at takeoff phase
+                                  obj.self.estimator.result.state.q(3)];    % yaw: current yaw angle
+                obj.fInit = obj.fInit + 1;
+            end
+            obj.result.state.xd = obj.gen_ref_for_go_to_flight_init(t - obj.base_time);
+            obj.result.state.p = obj.result.state.xd(1:3,1);
+            obj.result.state.v = obj.result.state.xd(5:7,1);
+        else
+            obj.result.state.xd = obj.takeoff_ref_class.result.state.xd;
+            obj.result.state.p = obj.result.state.xd(1:3,1);
+            obj.result.state.v = obj.result.state.xd(5:7,1);
+        end
+        result = obj.result;
+    end
+
+
+    function Xd = gen_ref_for_go_to_flight_init(obj, t)
+        %% Setting
+        % calc reference position and its higher time derivatives
+        % reference designed as a 9-degree polynomial function of time
+        % [Inputs]
+        % t : current time
+        %
+        % [Output]
+        % Xd : reference [[p;yd], [p^(1);0], [p^(2);0], [p^(3);0], [p^(4);0]] as column vector
+        %    : Xd in R^20
+        %    : yd is a yaw angle reference
+
+        %% Variable set
+        Xd  = zeros(20, 1);
+        %% Set Xd
+        if t<=obj.te
+            xd = curve_interpolation_9order(t, obj.te, obj.base_state(1), 0, obj.goal_state(1), 0);
+            yd = curve_interpolation_9order(t, obj.te, obj.base_state(2), 0, obj.goal_state(2), 0);
+            zd = curve_interpolation_9order(t, obj.te, obj.base_state(3), 0, obj.goal_state(3), 0);
+            yawd = curve_interpolation_9order(t, obj.te, obj.base_state(4), 0, obj.goal_state(4), 0);
+            % TODO: ↑curve_interpolation_9orderをベクトルに対応させるべき
+            tmp = [xd; yd; zd; yawd];
+            Xd = tmp(:);
+        elseif t> obj.te
+            Xd(1:4) = obj.goal_state;
+        end
+    end
+
+  end
+end

--- a/reference/GO_TO_FLIGHT_INITIAL_STATE_REFERENCE.m
+++ b/reference/GO_TO_FLIGHT_INITIAL_STATE_REFERENCE.m
@@ -67,8 +67,7 @@ classdef GO_TO_FLIGHT_INITIAL_STATE_REFERENCE < handle
             obj.fConvergence)
             if obj.fInit == 2
                 obj.base_time = t;
-                obj.base_state = [obj.self.estimator.result.state.p(1:2);...% x,y : current position
-                                  obj.self.reference.result.state.p(3);...  % z : reference using at takeoff phase
+                obj.base_state = [obj.self.reference.result.state.p;...     % x,y,z : reference using at takeoff phase
                                   obj.self.estimator.result.state.q(3)];    % yaw: current yaw angle
                 obj.fInit = obj.fInit + 1;
             end

--- a/reference/LANDING_REFERENCE.m
+++ b/reference/LANDING_REFERENCE.m
@@ -5,7 +5,7 @@ classdef LANDING_REFERENCE < handle
         vd
         dt
         result
-        base_state
+        base_state % [x;y;z;yaw]
         base_time = 0;
         te % 着陸するまでの時間
         initialz % 初期時刻高度（takeoffする前の高度）
@@ -36,13 +36,17 @@ classdef LANDING_REFERENCE < handle
             end
             if obj.fInit < 10 || isempty( obj.base_state ) % 飛行中にlanding modeに入った時点の情報を保存
                 if obj.fInit == 0              % 空回しの高度（=接地時高度）を保存
-                    obj.base_state = [obj.self.estimator.result.state.p(1:2);obj.self.reference.result.state.p(3)]; % x,y : current position, z : reference using at flight phase                    
+                    obj.base_state = [obj.self.estimator.result.state.p(1:2);... % x,y : current position
+                                      obj.self.reference.result.state.p(3);... % z : reference using at flight phase
+                                      obj.self.estimator.result.state.q(3)]; % yaw: current yaw angle
                 end
                 if obj.fInit == 1            % 直前の高度を保存
-                    obj.base_state = [obj.self.estimator.result.state.p(1:2);obj.self.reference.result.state.p(3)]; % x,y : current position, z : reference using at flight phase
+                    obj.base_state = [obj.self.estimator.result.state.p(1:2);... % x,y : current position
+                                      obj.self.reference.result.state.p(3);... % z : reference using at flight phase
+                                      obj.self.estimator.result.state.q(3)]; % yaw: current yaw angle
                 end
                 obj.base_time=varargin{1}.t;            
-                obj.result.state.xd = [obj.base_state;zeros(17,1)];
+                obj.result.state.xd = [obj.base_state;zeros(16,1)];
                 obj.fInit = obj.fInit + 1; % 降下し始めるまでのループカウント
                 % disp(obj.fInit)
             end
@@ -73,7 +77,7 @@ classdef LANDING_REFERENCE < handle
                 Zd = zeros(1,5);
                 Zd(1) = obj.initialz;
             end
-            Xd(1:3,1) = obj.base_state(1:3);
+            Xd(1:4,1) = obj.base_state(1:4);
             Xd(3,1) = Zd(1);
             Xd(7,1) = Zd(2);
             Xd(11,1) = Zd(3);

--- a/reference/TAKEOFF_REFERENCE.m
+++ b/reference/TAKEOFF_REFERENCE.m
@@ -3,7 +3,7 @@ classdef TAKEOFF_REFERENCE < handle
     param
     self
     base_time
-    base_state
+    base_state % [x;y;z;yaw]
     ts
     te % 目標高度に到達するまでの時間
     zd % goal altitude
@@ -28,8 +28,9 @@ classdef TAKEOFF_REFERENCE < handle
       % [Input] time,cha,logger,env
       if (obj.fInit < 2 || isempty( obj.base_state )) 
           obj.base_time=varargin{1}.t;
-          obj.base_state = obj.self.estimator.result.state.p; % x,y : current position, z : reference using at flight phase
-          obj.result.state.xd = [obj.base_state;zeros(17,1)];
+          obj.base_state = [obj.self.estimator.result.state.p;... % x,y : current position, z : reference using at flight phase
+                            obj.self.estimator.result.state.q(3)];% yaw: current yaw angle
+          obj.result.state.xd = [obj.base_state;zeros(16,1)];
           if varargin{2} == 't'
             obj.fInit = obj.fInit + 1;
           end
@@ -69,7 +70,7 @@ classdef TAKEOFF_REFERENCE < handle
         d3tra = 0;
         d4tra = 0;
       end
-      Xd(1:3,1) = obj.base_state(1:3);
+      Xd(1:4,1) = obj.base_state(1:4);
       Xd(3,1) = tra + Xd(3,1);
       Xd(7,1) = dtra;
       Xd(11,1) = ddtra;

--- a/reference/functions/gen_ref_circle.m
+++ b/reference/functions/gen_ref_circle.m
@@ -33,7 +33,7 @@ syms t real
 ref=@(t) [x_0+r*sin(2*pi*t/T+phase); %x
     y_0 + r*cos(2*pi*t/T+phase); %y
     z_0; %z
-    0];
+    pi/2];
 
 % 圧倒的に遅いので以下のような書き方はしないこと
 % xdf =@(t) [xd1(t),xd2(t),xd3(t),xd4(t)];

--- a/reference/functions/gen_ref_circle.m
+++ b/reference/functions/gen_ref_circle.m
@@ -33,7 +33,7 @@ syms t real
 ref=@(t) [x_0+r*sin(2*pi*t/T+phase); %x
     y_0 + r*cos(2*pi*t/T+phase); %y
     z_0; %z
-    pi/2];
+    0];
 
 % 圧倒的に遅いので以下のような書き方はしないこと
 % xdf =@(t) [xd1(t),xd2(t),xd3(t),xd4(t)];


### PR DESCRIPTION
## やったこと

* **TAKEOFF_REFERENCE, LANDING_REFERENCEの修正**
  * yawリファレンスに関して下表のような変更を行った
    |  | 修正前 | 修正後 |
    | ---- | ---- | ---- |
    | yaw_d | 0 | T/L押下時のyaw角 |
  * これにより、yaw角が急激に変化することがなくなった

* **GO_TO_FLIGHT_INITIAL_STATE_REFERENCEの実装**
  * TAKEOFF_REFERENCEの後にカスケードに実行されることを前提としたクラス
  * 「takeoffして設定時間te経過」かつ「高度が閾値σ未満になった」時に、flightフェーズ用に設定したリファレンスの初期状態(x, y, z, yaw)へと緩やかに移行

## やらないこと

* TAKEOFF_REFERENCEでzdを生成する時にはべた書きしたものを使用していて、それをcurve_interpolation_9order関数を使った形に修正すること
* TAKEOFF_REFERENCEにGO_TO_FLIGHT_INITIAL_STATE_REFERENCEの機能を入れること

## できるようになること（ユーザ目線）
* 実験で毎回真ん中に戻す必要がなくなる！！自動でflightリファレンスの初期状態に向かうため。
* 設定リファレンスによっては F 押下時にP2P指示が入ってしまって少し怖かったのが解消される。

## できなくなること（ユーザ目線）

* 無し
  * cha_allocationでカスケードにGO_TO_FLIGHT_INITIAL_STATE_REFERENCEを入れなければ従来通りの動作ができるため

## 動作確認

* SimHL
  * yaw初期値 = pi/2, pi/4, 0, -pi/2, -piに対して、緩やかに戻ることを確認
  * flight ref初期状態 (x,y,z,yaw) = (0,0,1,pi/2), (-1,0,1.25,pi/4) など様々な値に対しても緩やかに移行することを確認
* ExpHL
  * 高度の収束を判定する閾値がσ=5[cm]で問題ないことを確認
  * 連続して実験を行った際にflight ref初期値へ問題なく向かうことを確認
  * 実験ごとに移動させる手間が削減

## Concerns and areas to focus on
- ±180をまたぐような挙動の時に怪しい挙動を見せる。（コントローラ(HLC)側の処理の問題で調査中です）